### PR TITLE
Refactor config to be a class to give scope instead of using global config

### DIFF
--- a/lib/bindings/lookup_payee_bindings.dart
+++ b/lib/bindings/lookup_payee_bindings.dart
@@ -7,7 +7,7 @@ import 'package:pispapp/repositories/transaction_repository.dart';
 class LookupPayeeBinding implements Bindings {
   @override
   void dependencies() {
-    if (TRANSACTION_STUB)
+    if (Config.TRANSACTION_STUB)
       Get.put<LookupPayeeController>(
           LookupPayeeController(StubTransactionRepository()));
     else

--- a/lib/bindings/payment_details_bindings.dart
+++ b/lib/bindings/payment_details_bindings.dart
@@ -7,7 +7,7 @@ import 'package:pispapp/repositories/transaction_repository.dart';
 class PaymentDetailsBinding implements Bindings {
   @override
   void dependencies() {
-    if (TRANSACTION_STUB)
+    if (Config.TRANSACTION_STUB)
       Get.lazyPut<PaymentDetailsController>(
           () => PaymentDetailsController(StubTransactionRepository()));
     else

--- a/lib/bindings/payment_verdict_bindings.dart
+++ b/lib/bindings/payment_verdict_bindings.dart
@@ -7,7 +7,7 @@ import 'package:pispapp/repositories/transaction_repository.dart';
 class PaymentVerdictBinding implements Bindings {
   @override
   void dependencies() {
-    if (TRANSACTION_STUB)
+    if (Config.TRANSACTION_STUB)
       Get.lazyPut<PaymentVerdictController>(
           () => PaymentVerdictController(StubTransactionRepository()));
     else

--- a/lib/config/config.dart
+++ b/lib/config/config.dart
@@ -1,3 +1,8 @@
-const TRANSACTION_STUB = false;
-const STUB_PAYEE_NAME = 'John Doe';
-const ACCOUNT_STUB = false;
+class Config {
+  static const TRANSACTION_STUB = false;
+  static const STUB_PAYEE_NAME = 'John Doe';
+  static const ACCOUNT_STUB = false;
+  static const LOCAL_AUTH_GRACE_PERIOD_SECONDS = 10;
+  static const LOCAL_AUTH_PROMPT_ENABLED = false;
+}
+

--- a/lib/config/config.dart
+++ b/lib/config/config.dart
@@ -5,4 +5,3 @@ class Config {
   static const LOCAL_AUTH_GRACE_PERIOD_SECONDS = 10;
   static const LOCAL_AUTH_PROMPT_ENABLED = false;
 }
-

--- a/lib/controllers/ephemeral/dashboard_controller.dart
+++ b/lib/controllers/ephemeral/dashboard_controller.dart
@@ -24,7 +24,7 @@ class DashboardController extends GetxController {
 
   @override
   void onInit() {
-    if (TRANSACTION_STUB) {
+    if (Config.TRANSACTION_STUB) {
       Get.put<AccountDashboardController>(
           AccountDashboardController(StubTransactionRepository()));
       Get.put<PaymentInitiateController>(

--- a/lib/controllers/ephemeral/local_auth_controller.dart
+++ b/lib/controllers/ephemeral/local_auth_controller.dart
@@ -1,11 +1,11 @@
 import 'package:get/get.dart';
 import 'package:local_auth/local_auth.dart';
+import 'package:pispapp/config/config.dart';
 import 'package:pispapp/controllers/ephemeral/pin_entry_controller.dart';
 
 class LocalAuthController extends GetxController {
 
   // Timer for grace period
-  static const Duration gracePeriod = Duration(seconds: 10);
   DateTime _timestamp;
 
   // Used to prevent duplicates when resuming onto a verification screen
@@ -43,7 +43,9 @@ class LocalAuthController extends GetxController {
 
   void appWasResumed() {
     // Check if still within grace period
-    if(_timestamp == null || DateTime.now().difference(_timestamp) > gracePeriod) {
+    final bool longerThanGracePeriod = _timestamp == null ||
+        DateTime.now().difference(_timestamp) > const Duration(seconds: Config.LOCAL_AUTH_GRACE_PERIOD_SECONDS);
+    if(Config.LOCAL_AUTH_PROMPT_ENABLED && longerThanGracePeriod) {
       _onUserVerificationNeeded();
     }
   }

--- a/lib/controllers/ephemeral/lookup_payee_controller.dart
+++ b/lib/controllers/ephemeral/lookup_payee_controller.dart
@@ -15,8 +15,8 @@ class LookupPayeeController extends GetxController {
 
   @override
   void onInit() {
-    if (TRANSACTION_STUB == true) {
-      foundPayee(STUB_PAYEE_NAME);
+    if (Config.TRANSACTION_STUB == true) {
+      foundPayee(Config.STUB_PAYEE_NAME);
     }
     super.onInit();
     update();

--- a/lib/controllers/ephemeral/payment_details_controller.dart
+++ b/lib/controllers/ephemeral/payment_details_controller.dart
@@ -22,7 +22,7 @@ class PaymentDetailsController extends GetxController {
         Get.find<PaymentFinalizeController>().selectedAccount;
 
     await _transactionRepo.finalizePayment(transactionId, amount, payerAccount);
-    if (TRANSACTION_STUB) {
+    if (Config.TRANSACTION_STUB) {
       onQuoteAvailable('5');
     }
   }

--- a/lib/controllers/ephemeral/payment_verdict_controller.dart
+++ b/lib/controllers/ephemeral/payment_verdict_controller.dart
@@ -48,7 +48,7 @@ class PaymentVerdictController extends GetxController {
 
       _transactionRepo.authorizePayment(transactionId, signedString);
 
-      if (TRANSACTION_STUB) {
+      if (Config.TRANSACTION_STUB) {
         onSuccess();
       }
     } else {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -74,7 +74,7 @@ class _LifecycleAwareAppState extends State<LifecycleAwareApp> with WidgetsBindi
 void initAppControllers() {
   Get.put(AuthController(AuthRepository()));
 
-  if (ACCOUNT_STUB)
+  if (Config.ACCOUNT_STUB)
     Get.put(AccountController(StubAccountRepository()));
   else
     Get.put(AccountController(AccountRepository()));


### PR DESCRIPTION
The old implementation used a config.dart file where global constants were declared
I created config class to give scope. Quick PR